### PR TITLE
feat: add punkt_tab to NLTK data downloads

### DIFF
--- a/epicbox-python/310/Dockerfile
+++ b/epicbox-python/310/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt /tmp
 
 RUN pip install --no-cache-dir -r /tmp/requirements.txt \
-    && python -m nltk.downloader -d ${NLTK_DIR} averaged_perceptron_tagger brown gutenberg movie_reviews omw-1.4 punkt treebank word2vec_sample wordnet \
+    && python -m nltk.downloader -d ${NLTK_DIR} averaged_perceptron_tagger brown gutenberg movie_reviews omw-1.4 punkt punkt_tab treebank word2vec_sample wordnet \
     && wget -qO- https://download.cdn.yandex.net/mystem/mystem-3.1-linux-64bit.tar.gz | tar xvz -C ${MYSTEM_DIR} \
     && rm /tmp/requirements.txt
 

--- a/epicbox-python/311/Dockerfile
+++ b/epicbox-python/311/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt /tmp
 
 RUN pip install --no-cache-dir -r /tmp/requirements.txt \
-    && python -m nltk.downloader -d ${NLTK_DIR} averaged_perceptron_tagger brown gutenberg movie_reviews omw-1.4 punkt treebank word2vec_sample wordnet \
+    && python -m nltk.downloader -d ${NLTK_DIR} averaged_perceptron_tagger brown gutenberg movie_reviews omw-1.4 punkt punkt_tab treebank word2vec_sample wordnet \
     && wget -qO- https://download.cdn.yandex.net/mystem/mystem-3.1-linux-64bit.tar.gz | tar xvz -C ${MYSTEM_DIR} \
     && rm /tmp/requirements.txt
 

--- a/epicbox-python/312/Dockerfile
+++ b/epicbox-python/312/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt /tmp
 
 RUN pip install --no-cache-dir -r /tmp/requirements.txt \
-    && python -m nltk.downloader -d ${NLTK_DIR} averaged_perceptron_tagger brown gutenberg movie_reviews omw-1.4 punkt treebank word2vec_sample wordnet \
+    && python -m nltk.downloader -d ${NLTK_DIR} averaged_perceptron_tagger brown gutenberg movie_reviews omw-1.4 punkt punkt_tab treebank word2vec_sample wordnet \
     && wget -qO- https://download.cdn.yandex.net/mystem/mystem-3.1-linux-64bit.tar.gz | tar xvz -C ${MYSTEM_DIR} \
     && rm /tmp/requirements.txt
 


### PR DESCRIPTION
Add punkt_tab to the list of NLTK downloads in Python 3.10, 3.11, and 3.12 Dockerfiles to support additional text processing capabilities.

**YouTrack Issues**:
[#ALT-10756](https://vyahhi.myjetbrains.com/youtrack/issue/ALT-10756/Backend-Add-download-of-punkttab-model-when-building-python-images)

**Description**
